### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ AFAICT this was not possible with the original Optimist.  This can be set using 
    ```yaml
    dependencies:
      optimist:
-       github: nanobowers/optimist
+       github: nanobowers/optimist.cr
    ```
 
 2. Run `shards install`


### PR DESCRIPTION
The github repo address was pointing to a fork of the original ruby gem, instead of the Crystal port. Which was somewhat confusing for this Crystal noob, as it resulted in:

```
$ shards install
Resolving dependencies
…
Fetching https://github.com/nanobowers/optimist.git
Shard "optimist" version (2.1.2) doesn't have a shard.yml file
Installing optimist (2.1.2)
Unhandled exception: Error creating symlink: '..' -> '/path_to_app/lib/optimist/lib': File exists (File::AlreadyExistsError)
  from /usr/local/Cellar/crystal/1.3.2/bin/shards in 'raise<File::Error+>:NoReturn'
  from /usr/local/Cellar/crystal/1.3.2/bin/shards in 'File::symlink<String, String>:Nil'
  from /usr/local/Cellar/crystal/1.3.2/bin/shards in 'Shards::Package#install:Nil'
  from /usr/local/Cellar/crystal/1.3.2/bin/shards in 'Shards::Commands::Install@Shards::Command::run<String>:Nil'
  from /usr/local/Cellar/crystal/1.3.2/bin/shards in '~procProc(Array(String), Array(String), Nil)@src/cli.cr:56'
  from /usr/local/Cellar/crystal/1.3.2/bin/shards in 'OptionParser#parse<Array(String)>:Nil'
  from /usr/local/Cellar/crystal/1.3.2/bin/shards in '__crystal_main'
  from /usr/local/Cellar/crystal/1.3.2/bin/shards in 'main'
```